### PR TITLE
Added dbOptions to allow changing PouchDB options

### DIFF
--- a/L.TileLayer.PouchDBCached.js
+++ b/L.TileLayer.PouchDBCached.js
@@ -8,7 +8,11 @@ L.TileLayer.addInitHook(function() {
 		return;
 	}
 
-	this._db = new PouchDB('offline-tiles');
+	if (this.options.dbOptions) {
+		this._db = new PouchDB('offline-tiles', this.options.dbOptions);
+	} else {
+		this._db = new PouchDB('offline-tiles');
+	}
 	this._canvas = document.createElement('canvas');
 
 	if (!(this._canvas.getContext && this._canvas.getContext('2d'))) {


### PR DESCRIPTION
This allows passing options to PouchDB when it's created. This code is copied from `github.com/kwibus/Leaflet.TileLayer.PouchDBCached` and applied to the codebase of `github.com/nikolauskrismer/Leaflet.TileLayer.PouchDBCached`, thus effectively merging several pull requests that have not yet been accepted to the original base repository.